### PR TITLE
MSA-1372: Remove clock dependency from persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ BreakerBox.persistence_factory = PersistenceFactory
 The classes that `storage_for` returns must conform to the persistence interface. Specifically, the classes will need these methods:
 
  - `fail!`: Called when a breaker task fails
- - `clear!: Clears all previous failures
- - `all_within`: Returns an array of failures that happen within a timestamp
+ - `clear!`: Clears all previous failures
+ - `all_since`: Returns an array of failures that happen after a timestamp
  - `last_failure_time`: returns the last time a failure occured on this breaker
 
 Please looks in `BreakerBox::MemoryStorage` for an example implmentation.

--- a/lib/breaker_box/circuit.rb
+++ b/lib/breaker_box/circuit.rb
@@ -45,7 +45,7 @@ module BreakerBox
     protected
 
     def fail
-      @persistence.fail!
+      @persistence.fail!(Time.now.utc)
 
       if pertinent_failures.count >= @options[:failure_threshold_count]
         @state = :open
@@ -57,7 +57,7 @@ module BreakerBox
     end
 
     def pertinent_failures
-      @persistence.all_within(@options[:failure_threshold_time])
+      @persistence.all_since(Time.now.utc - @options[:failure_threshold_time])
     end
 
     def timeout_expired?

--- a/lib/breaker_box/memory_storage.rb
+++ b/lib/breaker_box/memory_storage.rb
@@ -4,16 +4,16 @@ module BreakerBox
       @failures = []
     end
 
-    def fail!
-      @failures << Time.now.utc
+    def fail!(timestamp)
+      @failures << timestamp
     end
 
     def clear!
       @failures = []
     end
 
-    def all_within(seconds)
-      @failures.select {|f| Time.now.utc - seconds < f}
+    def all_since(timestamp)
+      @failures.select {|f| timestamp < f}
     end
 
     def last_failure_time

--- a/spec/breaker_box/circuit_spec.rb
+++ b/spec/breaker_box/circuit_spec.rb
@@ -31,7 +31,7 @@ describe BreakerBox::Circuit do
     subject.closed?.should be_true
   end
 
-  it 'opens when the fail threshhold is met' do
+  it 'opens when the fail threshold is met' do
     (1..threshold).each do |n|
       subject.run failing_task
     end
@@ -44,7 +44,7 @@ describe BreakerBox::Circuit do
     subject.run failing_task
   end
 
-  it 'reraises the exception if a failure callback is not provided' do
+  it 're-raises the exception if a failure callback is not provided' do
     subject.failure_callback = nil
     lambda { subject.run failing_task }.should raise_error(FailingTask::CircuitBreakerException)
   end
@@ -69,7 +69,7 @@ describe BreakerBox::Circuit do
     task.has_run.should be_true
   end
 
-  it 'does not reopen immediately after reclosing' do
+  it 'does not reopen immediately after re-closing' do
     (1..threshold).each do |n|
       subject.run failing_task
     end
@@ -84,7 +84,7 @@ describe BreakerBox::Circuit do
     subject.closed?.should be_true
   end
 
-  it 'will tolerate fewer failures thant the threshold within the time interval' do
+  it 'will tolerate fewer failures than the threshold within the time interval' do
     subject.run failing_task
 
     Timecop.freeze Time.now.utc + 121


### PR DESCRIPTION
Changes the name of one method on persistence interface. Fixes some spelling mistakes in the specs.
