### PR TITLE
[ch87744]: Added paths to ignore all markdown files

### DIFF
--- a/.github/workflows/gem_push_beta.yml
+++ b/.github/workflows/gem_push_beta.yml
@@ -1,6 +1,9 @@
 name: breaker_box branch
 
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - '!**.md'
 
 env:
   BUNDLER_ACCESS_TOKEN: ${{ secrets.TECH_OPS_ACCESS_TOKEN }}

--- a/.github/workflows/gem_push_beta.yml
+++ b/.github/workflows/gem_push_beta.yml
@@ -2,8 +2,8 @@ name: breaker_box branch
 
 on:
   pull_request:
-    paths:
-      - '!**.md'
+    paths-ignore:
+      - '**.md'
 
 env:
   BUNDLER_ACCESS_TOKEN: ${{ secrets.TECH_OPS_ACCESS_TOKEN }}

--- a/.github/workflows/gem_push_master.yml
+++ b/.github/workflows/gem_push_master.yml
@@ -3,8 +3,8 @@ name: breaker_box master
 on:
   push:
     branches: [ master ]
-    paths:
-      - '!**.md'
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/gem_push_master.yml
+++ b/.github/workflows/gem_push_master.yml
@@ -3,6 +3,8 @@ name: breaker_box master
 on:
   push:
     branches: [ master ]
+    paths:
+      - '!**.md'
 
 jobs:
   build:

--- a/lib/breaker_box/version.rb
+++ b/lib/breaker_box/version.rb
@@ -1,3 +1,3 @@
 module BreakerBox
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'
 end


### PR DESCRIPTION
# Description
Our GitHub Actions workflows currently run for PRs that have only documentation changes in markdown files. Since no application code changes are made for documentation-only PRs, GitHub Actions should not build and release the application.

# AC
* Ignore markdown files in [all GitHub Actions workflows](https://github.com/search?q=org%3Asittercity+path%3A.github)

# Implementation Notes
* You can use [paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) to ignore all markdown files